### PR TITLE
Fix delete buttons

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -115,7 +115,6 @@ export default function Sidebar(props: any) {
                 if (res?.user_obj) {
                     setUserDetail(res?.user_obj)
                     setUserRole(res?.user_obj.role)
-                    console.log(userRole)
                     
                 }
             })
@@ -279,8 +278,8 @@ export default function Sidebar(props: any) {
                     </Box>
 
                 </Drawer>
-                <MyContextProvider>
-                <MyContext.Provider value={context}>
+                {/* <MyContextProvider> */}
+                {/* <MyContext.Provider value={context}> */}
 
                     {/* <Box sx={{ width: drawerWidth === 60 ? '1380px' : '1240px', ml: drawerWidth === 60 ? '60px' : '200px', overflowX: 'hidden' }}> */}
                     <Box sx={{ width: 'auto', ml: drawerWidth === 60 ? '60px' : '200px', overflowX: 'hidden' }}>
@@ -325,8 +324,8 @@ export default function Sidebar(props: any) {
                             <Route path='/app/cases/case-details' element={<CaseDetails />} />
                         </Routes>
                     </Box>
-                </MyContext.Provider>
-                </MyContextProvider>
+                {/* </MyContext.Provider> */}
+                {/* </MyContextProvider> */}
                 <OrganizationModal
                     open={organizationModal}
                     handleClose={organizationModalClose}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -57,7 +57,7 @@ export default function Sidebar(props: any) {
     const [organizationModal, setOrganizationModal] = useState(false)
     // const [navList, setNavList] = useState<string[]>(['deals', 'contacts', 'accounts', 'users']);
     const organizationModalClose = () => { setOrganizationModal(false) }
-    const { userRole, setUserRole } = useMyContext();
+    const { userRole, setUserRole, setUserId, userId, setProfileId, profileId } = useMyContext();
     console.log(userRole)
 
     useEffect(() => {
@@ -115,7 +115,8 @@ export default function Sidebar(props: any) {
                 if (res?.user_obj) {
                     setUserDetail(res?.user_obj)
                     setUserRole(res?.user_obj.role)
-                    
+                    setUserId(res?.user_obj.user_details.id)
+                    setProfileId(res?.user_obj.id)
                 }
             })
             .catch((error) => {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -39,6 +39,7 @@ import logo from '../assets/images/auth/img_logo.png';
 import { StyledListItemButton, StyledListItemText } from '../styles/CssStyled';
 // import MyContext, { MyContextData } from '../context/Context';
 import MyContext, { useMyContext } from '../context/Context';
+import { MyContextProvider } from '../context/Context';
 
 // declare global {
 //     interface Window {
@@ -278,6 +279,7 @@ export default function Sidebar(props: any) {
                     </Box>
 
                 </Drawer>
+                <MyContextProvider>
                 <MyContext.Provider value={context}>
 
                     {/* <Box sx={{ width: drawerWidth === 60 ? '1380px' : '1240px', ml: drawerWidth === 60 ? '60px' : '200px', overflowX: 'hidden' }}> */}
@@ -324,6 +326,7 @@ export default function Sidebar(props: any) {
                         </Routes>
                     </Box>
                 </MyContext.Provider>
+                </MyContextProvider>
                 <OrganizationModal
                     open={organizationModal}
                     handleClose={organizationModalClose}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -37,9 +37,7 @@ import { EditCase } from '../pages/cases/EditCase';
 import { CaseDetails } from '../pages/cases/CaseDetails';
 import logo from '../assets/images/auth/img_logo.png';
 import { StyledListItemButton, StyledListItemText } from '../styles/CssStyled';
-// import MyContext, { MyContextData } from '../context/Context';
 import MyContext, { useMyContext } from '../context/Context';
-import { MyContextProvider } from '../context/Context';
 
 // declare global {
 //     interface Window {

--- a/src/context/Context.tsx
+++ b/src/context/Context.tsx
@@ -9,15 +9,21 @@ import { createContext, useContext, useState } from 'react';
 interface MyContextData {
   userRole: string | null;
   setUserRole: (role: string | null) => void;
+  userId: string | null;
+  setUserId: (id: string | null) => void;
+  profileId: string | null;
+  setProfileId: (id: string | null) => void;
 }
 
 const MyContext = createContext<any>(undefined);
 
 export const MyContextProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [userRole, setUserRole] = useState<string | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
+  const [profileId, setProfileId] = useState<string | null>(null);
 
   return (
-      <MyContext.Provider value={{  userRole, setUserRole }}>
+      <MyContext.Provider value={{  userRole, setUserRole, userId, setUserId, profileId, setProfileId}}>
           {children}
       </MyContext.Provider>
   );

--- a/src/pages/accounts/Accounts.tsx
+++ b/src/pages/accounts/Accounts.tsx
@@ -132,7 +132,6 @@ type Item = {
 export default function Accounts() {
     const { userRole, setUserRole , userId} = useMyContext();
     const navigate = useNavigate()
-    console.log(userId, 'user id in Accounts')
 
     const [tab, setTab] = useState('open');
     const [loading, setLoading] = useState(true);

--- a/src/pages/accounts/Accounts.tsx
+++ b/src/pages/accounts/Accounts.tsx
@@ -17,6 +17,7 @@ import { Spinner } from '../../components/Spinner';
 import styled from '@emotion/styled';
 import '../../styles/style.css';
 import { EnhancedTableHead } from '../../components/EnchancedTableHead';
+import MyContext, { useMyContext } from '../../context/Context'
 
 interface HeadCell {
     disablePadding: boolean;
@@ -129,6 +130,7 @@ type Item = {
     id: string;
 };
 export default function Accounts() {
+    const { userRole, setUserRole } = useMyContext();
     const navigate = useNavigate()
 
     const [tab, setTab] = useState('open');
@@ -434,6 +436,7 @@ export default function Accounts() {
     const handleDelete = (id: any) => {
         console.log(id, 's;ected')
     }
+    const showAddButton = userRole !== 'USER' && userRole !== 'SALES REPRESENTATIVE';
     const modalDialog = 'Are You Sure You want to delete this Account?'
     const modalTitle = 'Delete Account'
 
@@ -496,14 +499,16 @@ export default function Accounts() {
                             <FiChevronRight style={{ height: '15px' }} />
                         </FabRight>
                     </Box>
-                    <Button
-                        variant='contained'
-                        startIcon={<FiPlus className='plus-icon' />}
-                        onClick={onAddAccount}
-                        className={'add-button'}
-                    >
-                        Add Account
-                    </Button>
+                    {showAddButton && (
+                        <Button
+                            variant='contained'
+                            startIcon={<FiPlus className='plus-icon' />}
+                            onClick={onAddAccount}
+                            className={'add-button'}
+                        >
+                            Add Account
+                        </Button>
+            )}
                 </Stack>
             </CustomToolbar>
             <Container sx={{ width: '100%', maxWidth: '100%', minWidth: '100%' }}>

--- a/src/pages/accounts/Accounts.tsx
+++ b/src/pages/accounts/Accounts.tsx
@@ -171,7 +171,6 @@ export default function Accounts() {
     const [closedAccountsCount, setClosedAccountsCount] = useState(0)
     const [closedAccountsOffset, setClosedAccountsOffset] = useState(0)
     const [deleteRowModal, setDeleteRowModal] = useState(false)
-    const [accountCreatedBy, setAccountCreatedBy] = useState('')
 
     const [selected, setSelected] = useState<string[]>([]);
     const [selectedId, setSelectedId] = useState<string[]>([]);
@@ -411,7 +410,6 @@ export default function Accounts() {
                 console.log(res, 'resDetail');
                 if (!res.error) {
                     const data = res?.account_obj
-                    setAccountCreatedBy(data.created_by)
                     navigate('/app/accounts/edit-account', {
                         state: {
                             value: {

--- a/src/pages/accounts/Accounts.tsx
+++ b/src/pages/accounts/Accounts.tsx
@@ -436,7 +436,7 @@ export default function Accounts() {
     const handleDelete = (id: any) => {
         console.log(id, 's;ected')
     }
-    const showAddButton = userRole !== 'USER' && userRole !== 'SALES REPRESENTATIVE';
+    const showAddButton = userRole !== 'USER' && userRole !== 'SALES REP';
     const modalDialog = 'Are You Sure You want to delete this Account?'
     const modalTitle = 'Delete Account'
 

--- a/src/pages/accounts/Accounts.tsx
+++ b/src/pages/accounts/Accounts.tsx
@@ -130,8 +130,9 @@ type Item = {
     id: string;
 };
 export default function Accounts() {
-    const { userRole, setUserRole } = useMyContext();
+    const { userRole, setUserRole , userId} = useMyContext();
     const navigate = useNavigate()
+    console.log(userId, 'user id in Accounts')
 
     const [tab, setTab] = useState('open');
     const [loading, setLoading] = useState(true);
@@ -170,6 +171,7 @@ export default function Accounts() {
     const [closedAccountsCount, setClosedAccountsCount] = useState(0)
     const [closedAccountsOffset, setClosedAccountsOffset] = useState(0)
     const [deleteRowModal, setDeleteRowModal] = useState(false)
+    const [accountCreatedBy, setAccountCreatedBy] = useState('')
 
     const [selected, setSelected] = useState<string[]>([]);
     const [selectedId, setSelectedId] = useState<string[]>([]);
@@ -409,6 +411,7 @@ export default function Accounts() {
                 console.log(res, 'resDetail');
                 if (!res.error) {
                     const data = res?.account_obj
+                    setAccountCreatedBy(data.created_by)
                     navigate('/app/accounts/edit-account', {
                         state: {
                             value: {
@@ -557,6 +560,7 @@ export default function Accounts() {
                                                     .map((item: any, index: any) => {
                                                         const labelId = `enhanced-table-checkbox-${index}`
                                                         const rowIndex = selectedId.indexOf(item.id);
+                
                                                         return (
                                                             <TableRow
                                                                 tabIndex={-1}
@@ -604,11 +608,14 @@ export default function Accounts() {
                                                                             style={{ fill: '#1A3353', cursor: 'pointer', width: '18px' }}
                                                                         />
                                                                     </IconButton> */}
-                                                                    <IconButton>
-                                                                        <FaTrashAlt
-                                                                            onClick={() => deleteRow(item?.id)}
-                                                                            style={{ fill: '#1A3353', cursor: 'pointer', width: '15px' }} />
-                                                                    </IconButton>
+                                                                    {userRole === 'ADMIN' || (userRole === 'SALES MANAGER' && item.created_by.id === userId) ? (
+                                                                        <IconButton>
+                                                                            <FaTrashAlt
+                                                                            onClick={() => deleteRow(item.id)}
+                                                                            style={{ fill: '#1A3353', cursor: 'pointer', width: '15px' }}
+                                                                            />
+                                                                        </IconButton>
+                                                                        ) : null}
                                                                 </TableCell>
                                                             </TableRow>
                                                         )
@@ -682,11 +689,14 @@ export default function Accounts() {
                                                                             style={{ fill: '#1A3353', cursor: 'pointer', width: '18px' }}
                                                                         />
                                                                     </IconButton> */}
-                                                                <IconButton>
-                                                                    <FaTrashAlt
-                                                                        onClick={() => deleteRow(item?.id)}
-                                                                        style={{ fill: '#1A3353', cursor: 'pointer', width: '15px' }} />
-                                                                </IconButton>
+                                                                {userRole === 'ADMIN' || (userRole === 'SALES MANAGER' && item.created_by.id === userId) ? (
+                                                                        <IconButton>
+                                                                            <FaTrashAlt
+                                                                            onClick={() => deleteRow(item.id)}
+                                                                            style={{ fill: '#1A3353', cursor: 'pointer', width: '15px' }}
+                                                                            />
+                                                                        </IconButton>
+                                                                        ) : null}
                                                             </TableCell>
                                                         </TableRow>
                                                     )

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -149,7 +149,7 @@ export default function Login() {
                     className="forget-password-link"
                     to={'/forget-password'}
                   >
-                    Forget password?
+                    Forgot password?
                   </Link>
                 </Typography>
                 <Button

--- a/src/pages/contacts/Contacts.tsx
+++ b/src/pages/contacts/Contacts.tsx
@@ -58,7 +58,7 @@ const headCells: readonly HeadCell[] = [
         id: '',
         numeric: true,
         disablePadding: false,
-        label: 'Action'
+        label: 'Actions'
     }
 ]
 

--- a/src/pages/contacts/Contacts.tsx
+++ b/src/pages/contacts/Contacts.tsx
@@ -97,7 +97,7 @@ export default function Contacts() {
     }, [currentPage, recordsPerPage]);
 
     useEffect(() => {
-        console.log('Component userRole:', userRole);
+        console.log('Current userRole:', userRole);
       }, [userRole]);
 
     // const handleChangeTab = (e: SyntheticEvent, val: any) => {
@@ -240,7 +240,7 @@ export default function Contacts() {
         setSelectedId('')
     }
 
-    const showAddButton = userRole !== 'USER' && userRole !== 'SALES REPRESENTATIVE';
+    const showAddButton = userRole !== 'USER' && userRole !== 'SALES REP';
     const modalDialog = 'Are You Sure you want to delete this contact?'
     const modalTitle = 'Delete Contact'
 
@@ -302,14 +302,16 @@ export default function Contacts() {
                             <FiChevronRight style={{ height: '15px' }} />
                         </FabRight>
                     </Box>
-                    <Button
-                        variant='contained'
-                        startIcon={<FiPlus className='plus-icon' />}
-                        onClick={onAddContact}
-                        className={'add-button'}
-                    >
-                        Add Contact
-                    </Button>
+                    {showAddButton && (
+                        <Button
+                            variant='contained'
+                            startIcon={<FiPlus className='plus-icon' />}
+                            onClick={onAddContact}
+                            className={'add-button'}
+                        >
+                            Add Contact
+                        </Button>
+            )}
                 </Stack>
             </CustomToolbar>
 

--- a/src/pages/contacts/Contacts.tsx
+++ b/src/pages/contacts/Contacts.tsx
@@ -85,8 +85,8 @@ export default function Contacts() {
     const [currentPage, setCurrentPage] = useState<number>(1);
     const [recordsPerPage, setRecordsPerPage] = useState<number>(10);
     const [totalPages, setTotalPages] = useState<number>(0);
-    const { userRole, setUserRole } = useMyContext();
-    console.log(userRole, 'Contacts user role')
+    const { userRole, setUserRole, userId} = useMyContext();
+    console.log(userId, 'Contacts user id')
 
     // useEffect(() => {
     //     getContacts()
@@ -96,9 +96,6 @@ export default function Contacts() {
         getContacts();
     }, [currentPage, recordsPerPage]);
 
-    useEffect(() => {
-        console.log('Current userRole:', userRole);
-      }, [userRole]);
 
     // const handleChangeTab = (e: SyntheticEvent, val: any) => {
     //     setValue(val)
@@ -348,6 +345,7 @@ export default function Contacts() {
                                             ? stableSort(contactList, getComparator(order, orderBy))
                                                 // .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((item: any, index: any) => {
                                                 .map((item: any, index: any) => {
+                                                    console.log(item.created_by,'item created by')
                                                     return (
                                                         <TableRow
                                                             tabIndex={-1}
@@ -361,7 +359,14 @@ export default function Contacts() {
                                                             {/* <StyledTableCell align='left'>
                                                 <AntSwitch checked={item.do_not_call} inputProps={{ 'aria-label': 'ant design' }} />
                                             </StyledTableCell> */}
-                                                            <TableCell className='tableCell'><FaTrashAlt style={{ cursor: 'pointer' }} onClick={() => deleteRow(item.id)} /></TableCell>
+                                                            <TableCell className='tableCell'>
+                                                                {userRole === 'ADMIN' || (userRole === 'SALES MANAGER' && item.created_by === userId) ? (
+                                                                    <FaTrashAlt
+                                                                    style={{ cursor: 'pointer' }}
+                                                                    onClick={() => deleteRow(item.id)}
+                                                                    />
+                                                                ) : null}
+                                                            </TableCell>
                                                         </TableRow>
                                                     )
                                                 })

--- a/src/pages/contacts/Contacts.tsx
+++ b/src/pages/contacts/Contacts.tsx
@@ -14,7 +14,7 @@ import { DeleteModal } from '../../components/DeleteModal';
 import { FiChevronUp } from '@react-icons/all-files/fi/FiChevronUp';
 import { FiChevronDown } from '@react-icons/all-files/fi/FiChevronDown';
 import { EnhancedTableHead } from '../../components/EnchancedTableHead';
-import { useMyContext } from '../../context/Context';
+import MyContext, { useMyContext } from '../../context/Context'
 
 interface HeadCell {
     disablePadding: boolean;
@@ -85,6 +85,8 @@ export default function Contacts() {
     const [currentPage, setCurrentPage] = useState<number>(1);
     const [recordsPerPage, setRecordsPerPage] = useState<number>(10);
     const [totalPages, setTotalPages] = useState<number>(0);
+    const { userRole, setUserRole } = useMyContext();
+    console.log(userRole, 'Contacts user role')
 
     // useEffect(() => {
     //     getContacts()
@@ -93,6 +95,10 @@ export default function Contacts() {
     useEffect(() => {
         getContacts();
     }, [currentPage, recordsPerPage]);
+
+    useEffect(() => {
+        console.log('Component userRole:', userRole);
+      }, [userRole]);
 
     // const handleChangeTab = (e: SyntheticEvent, val: any) => {
     //     setValue(val)
@@ -233,6 +239,8 @@ export default function Contacts() {
         setDeleteRowModal(false)
         setSelectedId('')
     }
+
+    const showAddButton = userRole !== 'USER' && userRole !== 'SALES REPRESENTATIVE';
     const modalDialog = 'Are You Sure you want to delete this contact?'
     const modalTitle = 'Delete Contact'
 

--- a/src/pages/leads/Leads.tsx
+++ b/src/pages/leads/Leads.tsx
@@ -17,6 +17,7 @@ import { FiChevronLeft } from "@react-icons/all-files/fi/FiChevronLeft";
 import { FiChevronRight } from "@react-icons/all-files/fi/FiChevronRight";
 import { CustomTab, CustomToolbar, FabLeft, FabRight } from '../../styles/CssStyled';
 import '../../styles/style.css'
+import MyContext, { useMyContext } from '../../context/Context'
 
 // import css from './css';
 // import emotionStyled from '@emotion/styled';
@@ -98,6 +99,7 @@ export const ToolbarNew = styled(Toolbar)({
 // }
 export default function Leads(props: any) {
   // const {drawer}=props
+  const { userRole, setUserRole } = useMyContext();
   const navigate = useNavigate()
   const [tab, setTab] = useState('open');
   const [loading, setLoading] = useState(true);
@@ -281,6 +283,7 @@ export default function Leads(props: any) {
       .catch(() => {
       })
   }
+  const showAddButton = userRole !== 'USER' && userRole !== 'SALES REP';
 
   const formatDate = (inputDate: string): string => {
     const currentDate = new Date();
@@ -374,14 +377,16 @@ export default function Leads(props: any) {
               <FiChevronRight style={{ height: '15px' }} />
             </FabRight>
           </Box>
-          <Button
-            variant='contained'
-            startIcon={<FiPlus className='plus-icon' />}
-            onClick={onAddHandle}
-            className={'add-button'}
-          >
-            Add Lead
-          </Button>
+          {showAddButton && (
+                        <Button
+                            variant='contained'
+                            startIcon={<FiPlus className='plus-icon' />}
+                            onClick={onAddHandle}
+                            className={'add-button'}
+                        >
+                            Add Lead
+                        </Button>
+            )}
         </Stack>
       </CustomToolbar>
 

--- a/src/pages/leads/Leads.tsx
+++ b/src/pages/leads/Leads.tsx
@@ -99,7 +99,7 @@ export const ToolbarNew = styled(Toolbar)({
 // }
 export default function Leads(props: any) {
   // const {drawer}=props
-  const { userRole, setUserRole } = useMyContext();
+  const { userRole, setUserRole, userId } = useMyContext();
   const navigate = useNavigate()
   const [tab, setTab] = useState('open');
   const [loading, setLoading] = useState(true);
@@ -404,9 +404,11 @@ export default function Leads(props: any) {
                       <div style={{ color: '#1A3353', fontSize: '1rem', fontWeight: '500', cursor: 'pointer' }} onClick={() => selectLeadList(item?.id)}>
                         {item?.title}
                       </div>
-                      <div onClick={() => deleteLead(item?.id)}>
-                        <FaTrashAlt style={{ cursor: 'pointer', color: 'gray' }} />
-                      </div>
+                      {userRole === 'ADMIN' || (userRole === 'SALES MANAGER' && item.created_by.id === userId) ? (
+                        <div onClick={() => deleteLead(item?.id)}>
+                          <FaTrashAlt style={{ cursor: 'pointer', color: 'gray' }} />
+                        </div>
+                        ) : null}
                     </Stack>
                     <Stack className='lead-row2'>
                       <div className='lead-row2-col1'>
@@ -492,9 +494,11 @@ export default function Leads(props: any) {
                       <div style={{ color: '#1A3353', fontSize: '1rem', fontWeight: '500', cursor: 'pointer' }} onClick={() => selectLeadList(item?.id)}>
                         {item?.title}
                       </div>
-                      <div onClick={() => deleteLead(item)}>
-                        <FaTrashAlt style={{ cursor: 'pointer', color: 'gray' }} />
-                      </div>
+                      {userRole === 'ADMIN' || (userRole === 'SALES MANAGER' && item.created_by.id === userId) ? (
+                        <div onClick={() => deleteLead(item?.id)}>
+                          <FaTrashAlt style={{ cursor: 'pointer', color: 'gray' }} />
+                        </div>
+                        ) : null}
                     </Stack>
                     <Stack className='lead-row2'>
                       <div className='lead-row2-col1'>

--- a/src/pages/opportunities/Opportunities.tsx
+++ b/src/pages/opportunities/Opportunities.tsx
@@ -15,6 +15,7 @@ import { DeleteModal } from '../../components/DeleteModal';
 import { FiChevronUp } from '@react-icons/all-files/fi/FiChevronUp';
 import { FiChevronDown } from '@react-icons/all-files/fi/FiChevronDown';
 import { EnhancedTableHead } from '../../components/EnchancedTableHead';
+import MyContext, { useMyContext } from '../../context/Context'
 
 
 interface HeadCell {
@@ -85,6 +86,7 @@ type Item = {
 };
 
 export default function Opportunities(props: any) {
+  const { userRole, setUserRole } = useMyContext();
   const navigate = useNavigate()
   const [tab, setTab] = useState('open');
   const [loading, setLoading] = useState(true);
@@ -292,6 +294,7 @@ export default function Opportunities(props: any) {
   };
   const modalDialog = 'Are You Sure You want to delete selected Opportunity?'
   const modalTitle = 'Delete Opportunity'
+  const showAddButton = userRole !== 'USER' && userRole !== 'SALES REP';
 
   const recordsList = [[10, '10 Records per page'], [20, '20 Records per page'], [30, '30 Records per page'], [40, '40 Records per page'], [50, '50 Records per page']]
   const tag = ['account', 'leading', 'account', 'leading', 'account', 'leading', 'account', 'account', 'leading', 'account', 'leading', 'account', 'leading', 'leading', 'account', 'account', 'leading', 'account', 'leading', 'account', 'leading', 'account', 'leading', 'account', 'leading', 'account', 'leading']
@@ -360,14 +363,16 @@ export default function Opportunities(props: any) {
                 <FiChevronRight style={{ height: '15px' }} />
               </FabRight>
             </Box>
-            <Button
-              variant='contained'
-              startIcon={<FiPlus className='plus-icon' />}
-              onClick={onAddOpportunity}
-              className={'add-button'}
-            >
-              Add Opportunity
-            </Button>
+            {showAddButton && (
+                        <Button
+                            variant='contained'
+                            startIcon={<FiPlus className='plus-icon' />}
+                            onClick={onAddOpportunity}
+                            className={'add-button'}
+                        >
+                            Add Opportunity
+                        </Button>
+            )}
           </Stack>
       </CustomToolbar>
       <Container sx={{ width: '100%', maxWidth: '100%', minWidth: '100%' }}>

--- a/src/pages/opportunities/Opportunities.tsx
+++ b/src/pages/opportunities/Opportunities.tsx
@@ -86,7 +86,7 @@ type Item = {
 };
 
 export default function Opportunities(props: any) {
-  const { userRole, setUserRole } = useMyContext();
+  const { userRole, setUserRole , userId} = useMyContext();
   const navigate = useNavigate()
   const [tab, setTab] = useState('open');
   const [loading, setLoading] = useState(true);
@@ -475,11 +475,14 @@ export default function Opportunities(props: any) {
                                                                             style={{ fill: '#1A3353', cursor: 'pointer', width: '18px' }}
                                                                         />
                                                                     </IconButton> */}
-                              <IconButton>
-                                <FaTrashAlt
-                                  onClick={() => deleteRow(item?.id)}
-                                  style={{ fill: '#1A3353', cursor: 'pointer', width: '15px' }} />
-                              </IconButton>
+                              {userRole === 'ADMIN' || (userRole === 'SALES MANAGER' && item.created_by.id === userId) ? (
+                                <IconButton>
+                                    <FaTrashAlt
+                                    onClick={() => deleteRow(item.id)}
+                                    style={{ fill: '#1A3353', cursor: 'pointer', width: '15px' }}
+                                    />
+                                </IconButton>
+                              ) : null}
                             </TableCell>
                           </TableRow>
                         )

--- a/src/pages/users/EditUser.tsx
+++ b/src/pages/users/EditUser.tsx
@@ -28,6 +28,7 @@ import { AntSwitch, RequiredTextField } from '../../styles/CssStyled'
 import { FiChevronDown } from '@react-icons/all-files/fi/FiChevronDown'
 import { FiChevronUp } from '@react-icons/all-files/fi/FiChevronUp'
 import '../../styles/style.css'
+import MyContext, { useMyContext } from '../../context/Context'
 
 type FormErrors = {
     email?: string[];
@@ -72,7 +73,7 @@ const roleOptions = [
 export function EditUser() {
     const { state } = useLocation()
     const navigate = useNavigate()
-
+    const { userRole, setUserRole } = useMyContext();
     const [reset, setReset] = useState(false)
     const [error, setError] = useState(false)
     const [errors, setErrors] = useState<FormErrors>({});
@@ -286,6 +287,8 @@ export function EditUser() {
                                                 />
                                             </div>
                                             <div className='fieldSubContainer'>
+                                            {userRole === 'ADMIN' && (
+                                                <>
                                                 <div className='fieldTitle'>Role</div>
                                                 <FormControl sx={{ width: '70%' }}>
                                                 <Select
@@ -309,6 +312,8 @@ export function EditUser() {
                 ))}
             </Select>
         </FormControl>
+        </>
+        )}
                                             </div>
                                         </div>
                                         <div className='fieldContainer2'>

--- a/src/pages/users/Users.tsx
+++ b/src/pages/users/Users.tsx
@@ -628,10 +628,11 @@ export default function Users() {
                                                                     style={{ fill: '#1A3353', cursor: 'pointer' }}
                                                                 /> */}
                                                                     </IconButton>
-                                                                    <IconButton>
-                                                                        <FaTrashAlt onClick={() => deleteRow(item?.id)} style={{ fill: '#1A3353', cursor: 'pointer', width: '15px' }} />
-                                                                        {/* <FaAd onClick={() => deleteItemBox(item)} style={{ fill: '#1A3353', cursor: 'pointer' }} /> */}
-                                                                    </IconButton>
+                                                                    {userRole === 'ADMIN' && (
+                                                                        <IconButton>
+                                                                        <FaTrashAlt onClick={() => deleteRow(item.id)} style={{ fill: '#1A3353', cursor: 'pointer', width: '15px' }} />
+                                                                        </IconButton>
+                                                                    )}
                                                                 </TableCell>
                                                             </TableRow>
                                                         )

--- a/src/pages/users/Users.tsx
+++ b/src/pages/users/Users.tsx
@@ -14,6 +14,7 @@ import { FaAd, FaEdit, FaTrashAlt } from 'react-icons/fa';
 import { fetchData } from '../../components/FetchData';
 import { UsersUrl, UserUrl } from '../../services/ApiUrls';
 import { CustomTab, CustomToolbar, FabLeft, FabRight } from '../../styles/CssStyled';
+import MyContext, { useMyContext } from '../../context/Context'
 
 interface HeadCell {
     disablePadding: boolean;
@@ -87,6 +88,7 @@ const roleDisplayMap: { [key: string]: string } = {
 
 export default function Users() {
     const navigate = useNavigate()
+    const { userRole, setUserRole } = useMyContext();
     const [tab, setTab] = useState('active');
     const [loading, setLoading] = useState(true);
     const [order, setOrder] = useState('asc')
@@ -428,6 +430,7 @@ export default function Users() {
     const handleDelete = (id: any) => {
         console.log(id, 's;ected')
     }
+    const showAddButton = userRole == 'ADMIN' ;
     const modalDialog = 'Are You Sure You want to delete this User?'
     const modalTitle = 'Delete User'
 
@@ -488,14 +491,16 @@ export default function Users() {
                             <FiChevronRight style={{ height: '15px' }} />
                         </FabRight>
                     </Box>
-                    <Button
-                        variant='contained'
-                        startIcon={<FiPlus className='plus-icon' />}
-                        onClick={onAddUser}
-                        className={'add-button'}
-                    >
-                        Add User
-                    </Button>
+                    {showAddButton && (
+                        <Button
+                            variant='contained'
+                            startIcon={<FiPlus className='plus-icon' />}
+                            onClick={onAddUser}
+                            className={'add-button'}
+                        >
+                            Add Account
+                        </Button>
+            )}
                 </Stack>
             </CustomToolbar>
             <Container sx={{ width: '100%', maxWidth: '100%', minWidth: '100%' }}>

--- a/src/pages/users/Users.tsx
+++ b/src/pages/users/Users.tsx
@@ -498,7 +498,7 @@ export default function Users() {
                             onClick={onAddUser}
                             className={'add-button'}
                         >
-                            Add Account
+                            Add User
                         </Button>
             )}
                 </Stack>


### PR DESCRIPTION
### Conditionally show `delete icons` and `add buttons` for all roles:

**Delete icons fixed accordingly to the role of current user:**

1. USER and SALES REP don't see delete icons.
2. SALES MANAGER sees delete buttons for Leads/Opportunities/Contacts/Accounts which were created by them and don't see delete icons for Users section. 
3. ADMIN sees delete icons for everything.

**All +Add buttons fixed accordingly to the role of current user:**

1. Only ADMIN sees `Add User` button
2. SALES MANAGER and ADMIN see `Add Contact/Lead/Opportunity/Account` buttons
3. SALES REP and USER don't see any `Add `buttons