### PR TITLE
fixed assign_to for leads and opportunities

### DIFF
--- a/src/pages/accounts/EditAccount.tsx
+++ b/src/pages/accounts/EditAccount.tsx
@@ -573,7 +573,7 @@ export function EditAccount() {
                                         </div>
                                         <div className='fieldContainer2'>
                                         <div className='fieldSubContainer'>
-                                        {userRole === 'ADMIN' || state.value.created_by.id === userId && (
+                                        {(userRole === 'ADMIN' || (state?.value?.created_by?.id === userId)) && (
                                             <>
                                                 <div className='fieldTitle'>Assign To</div>
                                                 <FormControl error={!!errors?.assigned_to?.[0]} sx={{ width: '70%' }}>

--- a/src/pages/leads/AddLeads.tsx
+++ b/src/pages/leads/AddLeads.tsx
@@ -355,7 +355,7 @@ export function AddLeads() {
   const crntPage = 'Add Leads'
   const backBtn = 'Back To Leads'
 
-  // console.log(state, 'leadsform')
+  console.log(state, 'leadsform')
   return (
     <Box sx={{ mt: '60px' }}>
       <CustomAppBar backbtnHandle={backbtnHandle} module={module} backBtn={backBtn} crntPage={crntPage} onCancel={onCancel} onSubmit={handleSubmit} />

--- a/src/pages/leads/EditLead.tsx
+++ b/src/pages/leads/EditLead.tsx
@@ -447,7 +447,8 @@ export function EditLead() {
     const crntPage = 'Edit Lead'
     const backBtn = 'Back To Lead Details'
 
-    // console.log(formData, 'leadsform')
+
+    console.log(state, 'state')
     return (
         <Box sx={{ mt: '60px' }}>
             <CustomAppBar backbtnHandle={backbtnHandle} module={module} backBtn={backBtn} crntPage={crntPage} onCancel={onCancel} onSubmit={handleSubmit} />
@@ -568,7 +569,7 @@ export function EditLead() {
                                                         limitTags={2}
                                                         options={state?.users || []}
                                                         // options={state.contacts ? state.contacts.map((option: any) => option) : ['']}
-                                                        getOptionLabel={(option: any) => state?.users ? option?.user_details?.email : option}
+                                                        getOptionLabel={(option: any) => state?.users ?  option?.user__email : option}
                                                         // getOptionLabel={(option: any) => option?.user__email}
                                                         onChange={(e: any, value: any) => handleChange2('assigned_to', value)}
                                                         size='small'
@@ -583,7 +584,7 @@ export function EditLead() {
 
                                                                     }}
                                                                     variant='outlined'
-                                                                    label={state?.users ? option?.user_details?.email : option}
+                                                                    label={state?.users ? option?.user__email : option}
                                                                     {...getTagProps({ index })}
                                                                 />
                                                             ))

--- a/src/pages/leads/EditLead.tsx
+++ b/src/pages/leads/EditLead.tsx
@@ -30,6 +30,7 @@ import { CustomPopupIcon, CustomSelectField, RequiredTextField, StyledSelect } f
 import { FiChevronDown } from '@react-icons/all-files/fi/FiChevronDown'
 import { FiChevronUp } from '@react-icons/all-files/fi/FiChevronUp'
 import '../../styles/style.css'
+import MyContext, { useMyContext } from '../../context/Context'
 
 // const useStyles = makeStyles({
 //   btnIcon: {
@@ -131,6 +132,7 @@ interface FormData {
 export function EditLead() {
     const navigate = useNavigate()
     const location = useLocation();
+    const { userRole , profileId, userId} = useMyContext();
     const { state } = location;
     const { quill, quillRef } = useQuill();
     // const initialContentRef = useRef(null);
@@ -446,6 +448,7 @@ export function EditLead() {
     const module = 'Leads'
     const crntPage = 'Edit Lead'
     const backBtn = 'Back To Lead Details'
+    console.log(state, 'leadsform')
 
 
     console.log(state, 'state')
@@ -559,6 +562,8 @@ export function EditLead() {
                                         </div>
                                         <div className='fieldContainer2'>
                                             <div className='fieldSubContainer'>
+                                            {(userRole === 'ADMIN' || (state?.value?.created_by?.id === userId)) && (
+                                                    <>
                                                 <div className='fieldTitle'>Assign To</div>
                                                 <FormControl error={!!errors?.assigned_to?.[0]} sx={{ width: '70%' }}>
                                                     <Autocomplete
@@ -608,6 +613,8 @@ export function EditLead() {
                                                     />
                                                     <FormHelperText>{errors?.assigned_to?.[0] || ''}</FormHelperText>
                                                 </FormControl>
+                                                </>
+                                                )}
                                             </div>
                                             <div className='fieldSubContainer'>
                                                 <div className='fieldTitle'>Industry</div>

--- a/src/pages/leads/LeadDetails.tsx
+++ b/src/pages/leads/LeadDetails.tsx
@@ -174,7 +174,7 @@ function LeadDetails(props: any) {
         // fetchData(`${LeadUrl}/comment/${state.leadId}/`, 'PUT', JSON.stringify(data), Header)
         fetchData(`${LeadUrl}/${state.leadId}/`, 'POST', JSON.stringify(data), Header)
             .then((res: any) => {
-                // console.log('Form data:', res);
+                console.log('Form data:', res);
                 if (!res.error) {
                     resetForm()
                     getLeadDetails(state?.leadId)
@@ -238,11 +238,12 @@ function LeadDetails(props: any) {
                     close_date: leadDetails?.close_date,
                     organization: leadDetails?.organization,
                     created_from_site: leadDetails?.created_from_site,
-                }, id: state?.leadId, tags: state?.tags || [], countries: state?.countries || [], source, status, industries, users, contacts, teams, comments
+                }, id: state?.leadId, tags: state?.tags || [], countries: state?.countries || [], source: state?.source || [], status: state?.status || [], industries: state?.industries|| [], users: state?.users || [], contacts: state?.contacts || [], teams: state?.teams || [], comments: state?.comments || []
             }
         }
         )
     }
+    console.log(state,'state')
 
     const handleAttachmentClick = () => {
         const fileInput = document.createElement('input');

--- a/src/pages/opportunities/EditOpportunity.tsx
+++ b/src/pages/opportunities/EditOpportunity.tsx
@@ -648,7 +648,7 @@ export function EditOpportunity() {
                                                 />
                                             </div>
                                             <div className='fieldSubContainer'>
-                                                {userRole === 'ADMIN' || state.value.created_by.id === userId && (
+                                            {(userRole === 'ADMIN' || (state?.value?.created_by?.id === userId)) && (
                                                     <>
                                                         <div className='fieldTitle'>Assign To</div>
                                                         <FormControl error={!!errors?.assigned_to?.[0]} sx={{ width: '70%' }}>

--- a/src/pages/opportunities/EditOpportunity.tsx
+++ b/src/pages/opportunities/EditOpportunity.tsx
@@ -72,6 +72,7 @@ interface FormData {
 export function EditOpportunity() {
     const navigate = useNavigate()
     const { state } = useLocation()
+    console.log(state, 'state')
     const { quill, quillRef } = useQuill();
     const initialContentRef = useRef<string | null>(null);
     const pageContainerRef = useRef<HTMLDivElement | null>(null);
@@ -655,7 +656,7 @@ export function EditOpportunity() {
                                                                 multiple
                                                                 value={selectedAssignTo}
                                                                 limitTags={2}
-                                                                options={state.users || []}
+                                                                options={state.users ? state.users.filter((option: any) => !selectedAssignTo.some((selectedOption) => selectedOption.id === option.id)) : []}
                                                                 getOptionLabel={(option: any) => state.users ? option?.user__email : option}
                                                                 onChange={(e: any, value: any) => handleChange2('assigned_to', value)}
                                                                 size='small'
@@ -670,7 +671,7 @@ export function EditOpportunity() {
 
                                                                             }}
                                                                             variant='outlined'
-                                                                            label={state.users ? option?.user_details?.email : option}
+                                                                            label={state.users ? option?.user__email : option}
                                                                             {...getTagProps({ index })}
                                                                         />
                                                                     ))


### PR DESCRIPTION
### Fixed assign to for Opportunities and Leads:

_**Note:** for testing use **exclude-role-user-from-context** branch in the backend_

1. In the Leads section not only admin shown in `assign to` dropdown. **All users** fetched from state. 
2. For both Leads and Opportunities when adding` assign to `users **full email shown as label** for the tags. 
